### PR TITLE
fix: use exec argument array to prevent payload splitting

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3452,7 +3452,7 @@ const exec_1 = __nccwpck_require3_(514);
 const main = () => {
     const payload = (0, core_1.getInput)('payload');
     const token = (0, core_1.getInput)('token');
-    (0, exec_1.exec)(`curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer ${token}" -d "${payload}" https://slack.com/api/chat.postMessage`);
+    (0, exec_1.exec)('curl', ['-X', 'POST', '-H', 'Content-type: application/json', '-H', `Authorization: Bearer ${token}`, '-d', payload, 'https://slack.com/api/chat.postMessage']);
 };
 process.on('unhandledRejection', (err) => {
     console.error(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,13 @@ const main = () => {
   const payload = getInput('payload', { required: true });
   const token = getInput('token', { required: true });
 
-  exec(`curl -X POST -H "Content-type: application/json" -H "Authorization: Bearer ${token}" -d "${payload}" https://slack.com/api/chat.postMessage`);
+  exec('curl', [
+    '-X', 'POST',
+    '-H', 'Content-type: application/json',
+    '-H', `Authorization: Bearer ${token}`,
+    '-d', payload,
+    'https://slack.com/api/chat.postMessage',
+  ]);
 }
 
 process.on('unhandledRejection', (err) => {


### PR DESCRIPTION
## Summary
- The `exec()` call was passing the entire curl command as a single template string, which caused `@actions/exec` to split the JSON payload on spaces
- This broke payloads containing spaces, Japanese characters, braces, or URLs — curl treated each word as a separate argument
- Use `exec(command, args[])` form so each argument is passed directly without splitting

## Root cause
```ts
// Before: single string gets split on spaces
exec(`curl ... -d "${payload}" ...`);

// After: argument array preserves payload as one value
exec('curl', ['-X', 'POST', ..., '-d', payload, ...]);
```

## Error example
```
curl: (6) Could not resolve host: science
curl: (3) unmatched close brace/bracket in URL position 53:
https://github.com/conocer/sx-claude-plugins/pull/97}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)